### PR TITLE
Update to new node.js version 24 to comply with upstream repo

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -69,4 +69,4 @@ ram.runtime = "50M"
     type = "postgresql"
 
     [resources.nodejs]
-    version = "20"
+    version = "24"


### PR DESCRIPTION
## Problem

- *Since commit d5de8a5 is moved to node.js 22 and with commit e6c86ae to node.js 24. Since then the menu of the game does not appear in yunohost version anymore. It is expected to correct this behaviour with updating the node.js version.*

## Solution

- *Update the node.js version to 24*

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)